### PR TITLE
ci: adding reusable workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,4 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     uses: outpost-os/pipeline-python/.github/workflows/lint.yml@v1
     with:
-      python-version: '3.12'
+      python-version: '3.10'


### PR DESCRIPTION
using local outpost-os reusable workflows for python packages