### PR TITLE
ci: allows push trigger for all jobs but lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 on:
+  push:
   pull_request:
     branches:
     - main


### PR DESCRIPTION
CI is triggered for both pull_request (on merge ref) and push (on head, being main after merge or the PR itself before merge)