### PR TITLE
pyproject,tox: remove useless devel deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,11 @@ dts2src = 'dts_utils.builder:main'
 
 [project.optional-dependencies]
 devel = [
-    "coverage>=0.4",
     "flake8>=7.0,<8.0",
-    "flake8-html>=0.4.3",
     "mypy>=1.8.0",
     "pytest>=4.6",
     "pytest-cov>=5.0.0",
     "black>=24.2,<25.0",
-    "cachetools>=5.3",
-    "lxml>=4.8.0",
     "pydoclint",
     "flake8-docstrings",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ min_version = 4.0
 env_list =
   lint
   unittests
-  htmlcov
   docs
 isolated_build = true
 
@@ -23,18 +22,11 @@ commands =
   coverage report -m
   coverage xml
 
-[testenv:htmlcov]
-commands =
-  coverage run --parallel-mode -m pytest {posargs}
-  coverage combine
-  coverage report
-  coverage html --directory=reports/testcov
-
 [testenv:lint]
 commands =
   black --line-length 100 --check --diff .
-  mypy -p dts_utils --html-report reports/mypycov
-  flake8  --format=html --htmldir=reports/flakereport --docstring-convention=numpy
+  mypy -p dts_utils
+  flake8  --docstring-convention=numpy
 
 [testenv:docs]
 extras = doc


### PR DESCRIPTION
htmlcov is not needed anymore, coverage is done through pytest and codecov.