### PR TITLE
node: support for useful properties accessor

### DIFF
--- a/src/dts_utils/node.py
+++ b/src/dts_utils/node.py
@@ -32,6 +32,14 @@ class Node:
             return self._node.labels[0]
         return ""
 
+    @property
+    def parent(self):
+        return self._node.parent
+
+    @property
+    def unit_addr(self):
+        return self._node.unit_addr
+
     def __getattr__(self, __name: str) -> Any:
         from .property import Property
 


### PR DESCRIPTION
Add support for parent (node) access from a given node. If node is root, returning oneself.
Add support for node address or identifier (id field) when using such a definition:
```dts
 label: name@id {
 };
 ```
 id can be an address or an identifier.